### PR TITLE
bump apsw version

### DIFF
--- a/memsql_loader/main.py
+++ b/memsql_loader/main.py
@@ -13,7 +13,7 @@ except ImportError:
         for the pip command:
 
             pip install \\
-                -e "git+git://github.com/rogerbinns/apsw.git@1be8f228f8b337f33f1a88ee55f61915133dd9b4#egg=apsw" \\
+                -e "git+git://github.com/rogerbinns/apsw.git@26b61c39a98db3ccad7f852adc944b0b8e94c242#egg=apsw" \\
                 --global-option="fetch" --global-option="--sqlite" --global-option="--missing-checksum-ok" \\
                 --global-option="build" --global-option="--enable-all-extensions"
         """))

--- a/scripts/apsw_install.sh
+++ b/scripts/apsw_install.sh
@@ -2,12 +2,12 @@
 
 ##### UPDATE memsql_loader/main.py if you change this file!
 
-pip freeze | grep -q "apsw.git@1be8f228f8b337f33f1a88ee55f61915133dd9b4"
+pip freeze | grep -q "apsw.git@26b61c39a98db3ccad7f852adc944b0b8e94c242"
 ret=$?
 if [ "$ret" != "0" ]
 then
     pip install \
-        -e "git+git://github.com/rogerbinns/apsw.git@1be8f228f8b337f33f1a88ee55f61915133dd9b4#egg=apsw" \
+        -e "git+git://github.com/rogerbinns/apsw.git@26b61c39a98db3ccad7f852adc944b0b8e94c242#egg=apsw" \
         --global-option="fetch" --global-option="--sqlite" --global-option="--missing-checksum-ok" \
         --global-option="build" --global-option="--enable-all-extensions"
 fi


### PR DESCRIPTION
fixes #19 
tested running and loading simple dataset

changes from previous apsw version:
```
3.17.0-r1

No APSW changes.

3.16.2-r1

Python 3.6 builds added.

Added SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE and SQLITE_FCNTL_PDB constants.

3.15.2-r1

No APSW changes.

3.15.1-r1

Added SQLITE_FCNTL_WIN32_GET_HANDLE constant.

3.15.0-r1

Added SQLITE_DBCONFIG_MAINDBNAME constant.

3.14.1-r1

Added SQLITE_DBSTATUS_CACHE_USED_SHARED and SQLITE_OK_LOAD_PERMANENTLY constants.

3.13.0-r1

Added SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION constant.

Added a :ref:`pip command line <really_want_pip>` in the :doc:`download` page.

3.12.2-r1

Call PyUnicode_READY for Python 3.3 onwards. Fixes :issue:`208`, :issue:`132`, :issue:`168`.

SQLite 3.12 completely changed the semantics of :meth:`VFS.xGetLastError` in an incompatible way. This required a rewrite of the relevant C, Python and test code. If you implement or use this method then you have to rewrite your code too. Also note that running the test suite from an earlier version of APSW against this or future SQLite versions will result in consuming all memory, swap or address space (an underlying integer changed meaning).

Added SQLITE_CONFIG_STMTJRNL_SPILL and SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER constants.

Added support for SQLITE_CONFIG_STMTJRNL_SPILL in :meth:`apsw.config`.

3.11.1-r1

setup.py attempts to use setuptools if present, before falling back to distutils. This allows setuptools only commands such as bdist_wheel to work. You can force use of distutils by setting the environment variable APSW_FORCE_DISTUTILS to any value. Note that setuptools may also affect the output file names. (:issue:`207`)

3.11.0-r1

The shell dump command now outputs the page size and user version. They were both output before as comments.

Updated SQLite download logic for 2016 folder.

Updated VFS test suite due to changes in SQLite default VFS implemented methods.

Added SQLITE_INDEX_CONSTRAINT_LIKE, SQLITE_INDEX_CONSTRAINT_REGEXP, SQLITE_INDEX_CONSTRAINT_GLOB, SQLITE_IOERR_AUTH, SQLITE_FCNTL_JOURNAL_POINTER, and SQLITE_FCNTL_VFS_POINTER constants.

Allow :class:`Connection` subclasses for backup api (:issue:`199`).

FTS5 and JSON1 extensions are now built by default for :doc:`--enable-all-extensions <build>`. It is recommended you wait a few more releases for these extensions to mature.

Added a mapping for virtual table scan flags

Use SQLITE_ENABLE_API_ARMOR for extra error checking.
```